### PR TITLE
fix query generation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ License: `use_mit_license()`, `use_gpl3_license()` or friends to
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Imports: 
     anytime,
     magrittr,

--- a/R/index.R
+++ b/R/index.R
@@ -3,7 +3,7 @@
 #'
 #' @param records a dataframe to be indexed
 #' @description The collection passed in must have the following specified columns:
-#' Title, Authors, Year, Publisher", Source, Misc, Journal Title, DOI
+#' Title, Authors, Year, Publisher, Source, Miscid, Journal Title, DOI
 #' @export 
 #' @importFrom solrium SolrClient collection_exists collection_create
 index_records = function (records, 

--- a/man/create_queries.Rd
+++ b/man/create_queries.Rd
@@ -4,10 +4,14 @@
 \alias{create_queries}
 \title{Convert dataframe of citations into search queries}
 \usage{
-create_queries(citations)
+create_queries(citations, boost_values = NULL, boost_fields = NULL)
 }
 \arguments{
 \item{citations}{dataframe of citations}
+
+\item{boost_values}{optional boost factors. Value is weight relative to other fields (e.g., ^2 is twice the weight) (see https://solr.apache.org/guide/7_3/the-standard-query-parser.html#boosting-a-term-with)}
+
+\item{boost_fields}{optional fields to boost weights}
 }
 \value{
 search queries

--- a/man/index_records.Rd
+++ b/man/index_records.Rd
@@ -11,5 +11,5 @@ index_records(records, collection_name = paste0(substitute(records)))
 }
 \description{
 The collection passed in must have the following specified columns:
-Title, Authors, Year, Publisher", Source, Misc, Journal Title, DOI
+Title, Authors, Year, Publisher, Source, Miscid, Journal Title, DOI
 }


### PR DESCRIPTION
query generation now treats titles correctly as phrases, and treats journal titles similarly